### PR TITLE
Fix parser not accounting for braces in function name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ function parseFirefox(lines: string[]): StackFrame[] {
 	});
 }
 
+// foo.bar.js:123:39
+// foo.bar.js:123:39 <- original.js:123:34
 const CHROME_MAPPED = /(.*?):(\d+):(\d+)(\s<-\s(.+):(\d+):(\d+))?/;
 function parseMapped(frame: StackFrame, maybeMapped: string) {
 	const match = maybeMapped.match(CHROME_MAPPED);
@@ -70,8 +72,12 @@ function parseMapped(frame: StackFrame, maybeMapped: string) {
 	}
 }
 
+// at <SomeFramework>
 const CHROME_IE_NATIVE_NO_LINE = /^at\s(<.*>)$/;
+// at <SomeFramework>:123:39
 const CHROME_IE_NATIVE = /^\s*at\s(<.*>):(\d+):(\d+)$/;
+// at foo.bar(bob) (foo.bar.js:123:39)
+// at foo.bar(bob) (foo.bar.js:123:39 <- original.js:123:34)
 const CHROME_IE_FUNCTION = /^at\s(.*)\s\((.*)\)$/;
 const CHROME_IE_DETECTOR = /\s*at\s.+/;
 

--- a/test/chrome.test.ts
+++ b/test/chrome.test.ts
@@ -254,4 +254,203 @@ describe("Chrome", () => {
 			},
 		]);
 	});
+
+	it("should parse codesandbox trace", () => {
+		const trace = `Error
+    at addHookStack (<anonymous>:2786:16)
+    at Object.o._hook.o.__h (<anonymous>:4189:10)
+    at v (https://t0e6p.csb.app/node_modules/preact/hooks/dist/hooks.module.js:85:63)
+    at Object.F [as useContext] (https://t0e6p.csb.app/node_modules/preact/hooks/dist/hooks.module.js:132:33)
+    at useTheme (https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/useTheme/useTheme.js:10:34)
+    at useStyles (https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/makeStyles/makeStyles.js:173:38)
+    at WithStyles (https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/withStyles/withStyles.js:48:21)
+    at Object.WithStyles(ForwardRef(ButtonBase)) (https://t0e6p.csb.app/node_modules/preact/compat/dist/compat.module.js:221:28)
+    at inspectHooks (<anonymous>:2972:22)
+    at inspectVNode (<anonymous>:3009:46)
+    at Object.inspect (<anonymous>:3935:21)
+    at Object.inspect (<anonymous>:4318:26)
+    at inspect (<anonymous>:1589:30)
+    at <anonymous>:1628:6
+		at <anonymous>:4590:32`;
+
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 16,
+				fileName: "<anonymous>",
+				line: 2786,
+				name: "addHookStack",
+				raw: "    at addHookStack (<anonymous>:2786:16)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 10,
+				fileName: "<anonymous>",
+				line: 4189,
+				name: "Object.o._hook.o.__h",
+				raw: "    at Object.o._hook.o.__h (<anonymous>:4189:10)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 63,
+				fileName:
+					"https://t0e6p.csb.app/node_modules/preact/hooks/dist/hooks.module.js",
+				line: 85,
+				name: "v",
+				raw:
+					"    at v (https://t0e6p.csb.app/node_modules/preact/hooks/dist/hooks.module.js:85:63)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 33,
+				fileName:
+					"https://t0e6p.csb.app/node_modules/preact/hooks/dist/hooks.module.js",
+				line: 132,
+				name: "Object.F [as useContext]",
+				raw:
+					"    at Object.F [as useContext] (https://t0e6p.csb.app/node_modules/preact/hooks/dist/hooks.module.js:132:33)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 34,
+				fileName:
+					"https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/useTheme/useTheme.js",
+				line: 10,
+				name: "useTheme",
+				raw:
+					"    at useTheme (https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/useTheme/useTheme.js:10:34)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 38,
+				fileName:
+					"https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/makeStyles/makeStyles.js",
+				line: 173,
+				name: "useStyles",
+				raw:
+					"    at useStyles (https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/makeStyles/makeStyles.js:173:38)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 21,
+				fileName:
+					"https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/withStyles/withStyles.js",
+				line: 48,
+				name: "WithStyles",
+				raw:
+					"    at WithStyles (https://t0e6p.csb.app/node_modules/@material-ui/styles/esm/withStyles/withStyles.js:48:21)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 28,
+				fileName:
+					"ForwardRef(ButtonBase)) (https://t0e6p.csb.app/node_modules/preact/compat/dist/compat.module.js",
+				line: 221,
+				name: "Object.WithStyles",
+				raw:
+					"    at Object.WithStyles(ForwardRef(ButtonBase)) (https://t0e6p.csb.app/node_modules/preact/compat/dist/compat.module.js:221:28)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 22,
+				fileName: "<anonymous>",
+				line: 2972,
+				name: "inspectHooks",
+				raw: "    at inspectHooks (<anonymous>:2972:22)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 46,
+				fileName: "<anonymous>",
+				line: 3009,
+				name: "inspectVNode",
+				raw: "    at inspectVNode (<anonymous>:3009:46)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 21,
+				fileName: "<anonymous>",
+				line: 3935,
+				name: "Object.inspect",
+				raw: "    at Object.inspect (<anonymous>:3935:21)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 26,
+				fileName: "<anonymous>",
+				line: 4318,
+				name: "Object.inspect",
+				raw: "    at Object.inspect (<anonymous>:4318:26)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 30,
+				fileName: "<anonymous>",
+				line: 1589,
+				name: "inspect",
+				raw: "    at inspect (<anonymous>:1589:30)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 6,
+				fileName: "<anonymous>",
+				line: 1628,
+				name: "",
+				raw: "    at <anonymous>:1628:6",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 32,
+				fileName: "<anonymous>",
+				line: 4590,
+				name: "",
+				raw: "\t\tat <anonymous>:4590:32",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+		]);
+	});
 });

--- a/test/chrome.test.ts
+++ b/test/chrome.test.ts
@@ -36,7 +36,7 @@ describe("Chrome", () => {
 				name: "",
 				line: 1,
 				column: 13,
-				type: "",
+				type: "native",
 				fileName: "<anonymous>",
 				raw: "    at <anonymous>:1:13",
 				sourceColumn: -1,
@@ -194,11 +194,11 @@ describe("Chrome", () => {
 				sourceLine: 435,
 			},
 			{
-				name: "Jasmine",
+				name: "",
 				line: -1,
 				column: -1,
 				type: "native",
-				fileName: "",
+				fileName: "<Jasmine>",
 				raw: "  at <Jasmine>",
 				sourceColumn: -1,
 				sourceFileName: "",
@@ -212,11 +212,11 @@ describe("Chrome", () => {
 
 		expect(parseStackTrace(trace)).to.deep.equal([
 			{
-				name: "Test",
+				name: "",
 				line: -1,
 				column: -1,
 				type: "native",
-				fileName: "",
+				fileName: "<Test>",
 				raw: "  at <Test>",
 				sourceColumn: -1,
 				sourceFileName: "",
@@ -251,6 +251,38 @@ describe("Chrome", () => {
 				sourceColumn: -1,
 				sourceFileName: "",
 				sourceLine: -1,
+			},
+		]);
+	});
+
+	it("should match function with parens", () => {
+		const trace = `Error
+  at addHookStack (<anonymous>:2786:16)
+  at Object.WithStyles(ForwardRef(ButtonBase)) (https://example.com/foo.js:221:28)`;
+
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 16,
+				fileName: "<anonymous>",
+				line: 2786,
+				name: "addHookStack",
+				raw: "  at addHookStack (<anonymous>:2786:16)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 28,
+				fileName: "https://example.com/foo.js",
+				line: 221,
+				name: "Object.WithStyles(ForwardRef(ButtonBase))",
+				raw:
+					"  at Object.WithStyles(ForwardRef(ButtonBase)) (https://example.com/foo.js:221:28)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
 			},
 		]);
 	});
@@ -364,9 +396,9 @@ describe("Chrome", () => {
 			{
 				column: 28,
 				fileName:
-					"ForwardRef(ButtonBase)) (https://t0e6p.csb.app/node_modules/preact/compat/dist/compat.module.js",
+					"https://t0e6p.csb.app/node_modules/preact/compat/dist/compat.module.js",
 				line: 221,
-				name: "Object.WithStyles",
+				name: "Object.WithStyles(ForwardRef(ButtonBase))",
 				raw:
 					"    at Object.WithStyles(ForwardRef(ButtonBase)) (https://t0e6p.csb.app/node_modules/preact/compat/dist/compat.module.js:221:28)",
 				sourceColumn: -1,
@@ -438,7 +470,7 @@ describe("Chrome", () => {
 				sourceColumn: -1,
 				sourceFileName: "",
 				sourceLine: -1,
-				type: "",
+				type: "native",
 			},
 			{
 				column: 32,
@@ -449,7 +481,7 @@ describe("Chrome", () => {
 				sourceColumn: -1,
 				sourceFileName: "",
 				sourceLine: -1,
-				type: "",
+				type: "native",
 			},
 		]);
 	});

--- a/test/webpack.test.ts
+++ b/test/webpack.test.ts
@@ -36,7 +36,7 @@ describe("Webpack", () => {
 				name: "",
 				line: 1,
 				column: 13,
-				type: "",
+				type: "native",
 				fileName: "<anonymous>",
 				raw: "    at <anonymous>:1:13",
 				sourceColumn: -1,


### PR DESCRIPTION
Previously the parser would parse the content inside the braces of this function `Object.WithStyles(ForwardRef(ButtonBase))` as the file name.

- Removes browser specific parsing exports (accidentally exposed them earlier)
- Adds extra step for parsing mapping location to make internals a lot easier to maintain (the regex was getting out of hand)
- Treat `at <anonymous>:2:1` as `native` and mark `<anonymous>` as the file name
- Keep the `<>` characters instead of removing them