### PR TITLE
Parse errors thrown on internal browser pages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,8 @@ const CHROME_IE_NATIVE = /^\s*at\s(<.*>):(\d+):(\d+)$/;
 // at foo.bar(bob) (foo.bar.js:123:39 <- original.js:123:34)
 const CHROME_IE_FUNCTION = /^at\s(.*)\s\((.*)\)$/;
 const CHROME_IE_DETECTOR = /\s*at\s.+/;
+// at about:blank:1:7
+const CHROME_BLANK = /\s*at\s(.*):(\d+):(\d+)/;
 
 function parseChromeIe(lines: string[]): StackFrame[] {
 	// Many frameworks mess with error.stack. So we use this check
@@ -118,6 +120,15 @@ function parseChromeIe(lines: string[]): StackFrame[] {
 		if (withFn) {
 			frame.name = withFn[1];
 			parseMapped(frame, withFn[2]);
+			frames.push(frame);
+			continue;
+		}
+
+		const blank = str.match(CHROME_BLANK);
+		if (blank) {
+			frame.fileName = blank[1];
+			frame.line = +blank[2];
+			frame.column = +blank[3];
 			frames.push(frame);
 			continue;
 		}

--- a/test/chrome.test.ts
+++ b/test/chrome.test.ts
@@ -485,4 +485,110 @@ describe("Chrome", () => {
 			},
 		]);
 	});
+
+	it("should parse lines with no function names", () => {
+		const trace = `Error: my error msg
+    at c (<anonymous>:1:17)
+    at b (<anonymous>:2:17)
+    at a (<anonymous>:3:17)
+    at <anonymous>:4:13
+`;
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 17,
+				fileName: "<anonymous>",
+				line: 1,
+				name: "c",
+				raw: "    at c (<anonymous>:1:17)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 17,
+				fileName: "<anonymous>",
+				line: 2,
+				name: "b",
+				raw: "    at b (<anonymous>:2:17)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 17,
+				fileName: "<anonymous>",
+				line: 3,
+				name: "a",
+				raw: "    at a (<anonymous>:3:17)",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 13,
+				fileName: "<anonymous>",
+				line: 4,
+				name: "",
+				raw: "    at <anonymous>:4:13",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "native",
+			},
+		]);
+	});
+
+	it("should parse new tab page error", () => {
+		const trace = `Error: error in module\n    at chrome://new-tab-page/:1:7`;
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 7,
+				fileName: "chrome://new-tab-page/",
+				line: 1,
+				name: "",
+				raw: "    at chrome://new-tab-page/:1:7",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+		]);
+	});
+
+	it("should parse about:blank page error", () => {
+		const trace = `Error: error in module\n    at about:blank:1:7`;
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 7,
+				fileName: "about:blank",
+				line: 1,
+				name: "",
+				raw: "    at about:blank:1:7",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+		]);
+	});
+
+	it("should parse anonymous error", () => {
+		const trace = `Error: error in module\n    at <anonymous>:4:13`;
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 13,
+				fileName: "<anonymous>",
+				line: 4,
+				name: "",
+				raw: "    at <anonymous>:4:13",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "native",
+			},
+		]);
+	});
 });

--- a/test/firefox.test.ts
+++ b/test/firefox.test.ts
@@ -121,4 +121,32 @@ describe("Firefox", () => {
 			},
 		]);
 	});
+
+	it("should parse errors from about:blank", () => {
+		const trace = `@about:blank line 5 > injectedScript:1:7\n@debugger eval code:5:15\n`;
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 7,
+				fileName: "about:blank line 5 > injectedScript",
+				line: 1,
+				name: "",
+				raw: "@about:blank line 5 > injectedScript:1:7",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+			{
+				column: 15,
+				fileName: "debugger eval code",
+				line: 5,
+				name: "",
+				raw: "@debugger eval code:5:15",
+				sourceColumn: -1,
+				sourceFileName: "",
+				sourceLine: -1,
+				type: "",
+			},
+		]);
+	});
 });


### PR DESCRIPTION
This PR adds support for parsing errors thrown from internal pages like `about:blank`.

Fixes #5 