### PR TITLE
Return empty stack if err.stack is undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,9 @@ function parseChromeIe(lines: string[]): StackFrame[] {
 	return frames;
 }
 
-export function parseStackTrace(stack: string): StackFrame[] {
+export function parseStackTrace(stack: string | undefined): StackFrame[] {
+	if (!stack) return [];
+
 	const lines = stack.split("\n").filter(Boolean);
 
 	// Libraries like node's "assert" module mess with the stack trace by

--- a/test/general.test.ts
+++ b/test/general.test.ts
@@ -1,0 +1,8 @@
+import { expect } from "chai";
+import { parseStackTrace } from "../src";
+
+describe("general", () => {
+	it("should not throw when stack trace is missing", () => {
+		expect(() => parseStackTrace(undefined)).not.to.throw();
+	});
+});


### PR DESCRIPTION
The `error.stack` property is optional and therefore may be `undefined`. We should guard against this. See https://github.com/preactjs/wmr/pull/498/files

```js
const err = new Error("fail");
parseStackTrace(err.stack); // err.stack might be undefined
```