### PR TITLE
Add support for node 12 esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "dist/types/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/esm/index.mjs",
+			"require": "./dist/cjs/index.js"
+		},
+		"./package.json": "./package.json",
+		"./": "./"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/marvinhagemeister/errorstacks.git"
@@ -17,7 +25,7 @@
 	],
 	"scripts": {
 		"test": "mocha -r ts-node/register --extension ts 'test/*test.ts'",
-		"build": "rimraf dist/ && tsc && tsc -p tsconfig.esm.json",
+		"build": "rimraf dist/ && tsc && tsc -p tsconfig.esm.json && node tools/postbuild.js && check-export-map",
 		"format": "prettier --write src/**/*.ts test/**/*.ts",
 		"prepublishOnly": "npm run build"
 	},
@@ -28,6 +36,7 @@
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.11.0",
 		"chai": "^4.2.0",
+		"check-export-map": "^1.0.1",
 		"husky": "^4.3.0",
 		"lint-staged": "^10.4.0",
 		"mocha": "^7.1.1",

--- a/tools/postbuild.js
+++ b/tools/postbuild.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+const path = require("path");
+
+const source = path.join(__dirname, "..", "dist", "esm", "index.js");
+const dest = path.join(path.dirname(source), "index.mjs");
+
+fs.writeFileSync(dest, fs.readFileSync(source));

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,6 +212,14 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
+check-export-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/check-export-map/-/check-export-map-1.0.1.tgz#5d77a48b32fb2e28a382a1bea22f3dd198d5f65f"
+  integrity sha512-6nJK5v9fiUQjAACrLyVlIm8UlAak5zdvYxJhpl0zYa7IqUElInMU6lRL/+rTHjEmy+hbkn5Wphq4Rj9cRkEbqg==
+  dependencies:
+    kolorist "^1.2.3"
+    mri "^1.1.6"
+
 chokidar@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.0.tgz#12c0714668c55800f659e262d4962a97faf554a6"
@@ -746,6 +754,11 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+kolorist@^1.2.3:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.3.2.tgz#3d939b3b2e42e7cf9b2ac1f385c33041cfe42207"
+  integrity sha512-0AABCl2usZg6CptLfHW4N3ZhGUT6vgHO6CtBOsRJKQGgvhKRWryUtXGfADLpK2XxbLh/VOXFX7EluitkSgP/eA==
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -901,6 +914,11 @@ mocha@^7.1.1:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
+
+mri@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.6.tgz#49952e1044db21dbf90f6cd92bc9c9a777d415a6"
+  integrity sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==
 
 ms@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This allows Node `>=12.20.0` to import our module in esm mode via named exports.