### PR TITLE
Parse Chrome 99 trace without braces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,8 @@ const CHROME_IE_FUNCTION = /^at\s(.*)\s\((.*)\)$/;
 const CHROME_IE_FUNCTION_WITH_CALL = /^([\w\W]*)\s\((.*)\)/;
 const CHROME_IE_DETECTOR = /\s*at\s.+/;
 // at about:blank:1:7
+// >= Chrome 99
+// at /projects/foo.test.js:689:1 <- /projects/foo.test.js:10:1
 const CHROME_BLANK = /\s*at\s(.*):(\d+):(\d+)$/;
 
 function parseChromeIe(lines: string[]): StackFrame[] {
@@ -171,6 +173,7 @@ function parseChromeIe(lines: string[]): StackFrame[] {
 			frame.fileName = blank[1];
 			frame.line = +blank[2];
 			frame.column = +blank[3];
+			parseMapped(frame, `${blank[1]}:${blank[2]}:${blank[3]}`);
 			frames.push(frame);
 			continue;
 		}

--- a/test/chrome.test.ts
+++ b/test/chrome.test.ts
@@ -640,4 +640,37 @@ describe("Chrome", () => {
 			},
 		]);
 	});
+
+	it("should parse Chrome 99 trace without braces", () => {
+		const trace = `Error: fail\n  at updater2 (/projects/preact/reactive/src/index.js:334:9 <- /projects/preact/reactive/test/browser/reactive.test.js:940:13)\n  at /projects/preact/reactive/test/browser/reactive.test.js:689:14 <- /projects/preact/reactive/test/browser/reactive.test.js:1904:18`;
+
+		expect(parseStackTrace(trace)).to.deep.equal([
+			{
+				column: 9,
+				fileName: "/projects/preact/reactive/src/index.js",
+				line: 334,
+				name: "updater2",
+				raw:
+					"  at updater2 (/projects/preact/reactive/src/index.js:334:9 <- /projects/preact/reactive/test/browser/reactive.test.js:940:13)",
+				sourceColumn: 13,
+				sourceFileName:
+					"/projects/preact/reactive/test/browser/reactive.test.js",
+				sourceLine: 940,
+				type: "",
+			},
+			{
+				column: 14,
+				fileName: "/projects/preact/reactive/test/browser/reactive.test.js",
+				line: 689,
+				name: "",
+				raw:
+					"  at /projects/preact/reactive/test/browser/reactive.test.js:689:14 <- /projects/preact/reactive/test/browser/reactive.test.js:1904:18",
+				sourceColumn: 18,
+				sourceFileName:
+					"/projects/preact/reactive/test/browser/reactive.test.js",
+				sourceLine: 1904,
+				type: "",
+			},
+		]);
+	});
 });


### PR DESCRIPTION
Just came across this trace format in Chrome 99 where the file paths aren't wrapped in braces.

```txt
  at /projects/preact/reactive/test/browser/reactive.test.js:689:14 <- /projects/preact/reactive/test/browser/reactive.test.js:1904:18
```