### PR TITLE
fix: expose types in export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"types": "dist/types/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/types/index.d.ts",
 			"import": "./dist/esm/index.mjs",
 			"require": "./dist/cjs/index.js"
 		},


### PR DESCRIPTION
When using `nodenext` resolution in typescript, the compiler will not fall back to top-level `types` and will instead expect there to be a sibling `d.ts` file or a `types` entry in the export.

This means currently errorstacks fails builds in modern typescript setups.

This fix introduces a `types` entry for the export, which points at the same definition file as the top-level `types`.

You can read more about that via this tool:
https://arethetypeswrong.github.io/?p=errorstacks%402.4.0